### PR TITLE
Don't try to uninstall the shared libraries unless the directory exists.

### DIFF
--- a/src/tools/make/oberon.mk
+++ b/src/tools/make/oberon.mk
@@ -189,8 +189,8 @@ installable:
 
 uninstall: installable
 	@printf '\nUninstalling from \"$(INSTALLDIR)\"\n'
+	@[ -d "$(INSTALLDIR)/lib" ] && sh src/tools/make/addlibrary.sh uninstall "$(INSTALLDIR)/lib" $(ONAME) || echo nolibdir, skipping
 	rm -rf "$(INSTALLDIR)"
-	@sh src/tools/make/addlibrary.sh uninstall "$(INSTALLDIR)/lib" $(ONAME)
 
 
 # install: Use only after a successful full build. Installs the compiler


### PR DESCRIPTION
Otherwise it fails on OpenBSD during the first installation with:

    ldconfig: /usr/local/sw/versions/voc/git/lib: No such file or directory