### PR TITLE
modified Index checking to handle run-time variable index containing …

### DIFF
--- a/src/runtime/SYSTEM.h
+++ b/src/runtime/SYSTEM.h
@@ -116,9 +116,11 @@ extern void Modules_AssertFail(INT32 x);
 
 // Index checking
 
-static inline INT64 __XF(UINT64 i, UINT64 ub) {if (i >= ub) {__HALT(-2);} return i;}
-#define __X(i, ub) (((i)<(ub))?i:(__HALT(-2),0))
-
+static inline INT64 __XF(INT64 i, UINT64 ub) {
+  if (i < 0 || (UINT64)i >= ub) __HALT(-2);
+  return i;
+}
+#define __X(i, ub) (((i) >= 0 && (i) < (ub)) ? (i) : (__HALT(-2),0))
 
 // Range checking, and checked SHORT and CHR functions
 


### PR DESCRIPTION
The previous logic assumed indices were non‑negative, which caused out‑of‑bounds access when a runtime variable held negative value. We now guard against negative values run-time, with halt -2.